### PR TITLE
Runs 'store_name' through a translit operation before using it

### DIFF
--- a/src/upload/catalog/controller/extension/payment/simplifycommerce.php
+++ b/src/upload/catalog/controller/extension/payment/simplifycommerce.php
@@ -26,7 +26,7 @@ class ControllerExtensionPaymentSimplifyCommerce extends Controller {
         $encoding = mb_detect_encoding($field);
         if ($encoding !== 'ASCII') {
             if (function_exists('transliterator_transliterate')) {
-                $field = transliterator_transliterate('Any-Latin; Latin-ASCII', $field);
+                $field = transliterator_transliterate('Any-Latin; Latin-ASCII; [\u0080-\u7fff] remove', $field);
 		    } else if (function_exists('iconv')) {
                 // fall back to iconv if intl module not available
                 $field = iconv($encoding, 'ASCII//TRANSLIT//IGNORE', $field);

--- a/src/upload/catalog/controller/extension/payment/simplifycommerce.php
+++ b/src/upload/catalog/controller/extension/payment/simplifycommerce.php
@@ -22,23 +22,15 @@ class ControllerExtensionPaymentSimplifyCommerce extends Controller {
 	}
 
     protected function attempt_transliteration($field) {
-	    $copy = $field;
         $encoding = mb_detect_encoding($field);
         if ($encoding !== 'ASCII') {
             if (function_exists('transliterator_transliterate')) {
                 $field = transliterator_transliterate('Any-Latin; Latin-ASCII; [\u0080-\u7fff] remove', $field);
-		    } else if (function_exists('iconv')) {
+		    } else {
                 // fall back to iconv if intl module not available
                 $field = iconv($encoding, 'ASCII//TRANSLIT//IGNORE', $field);
                 $field = str_ireplace('?', '', $field);
                 $field = trim($field);
-            } else {
-                // no transliteration possible, revert to original field
-                return $field;
-            }
-            if (!$field) {
-                // if translit turned the string into any false-like value, return original instead
-                return $copy;
             }
         }
         return $field;

--- a/src/upload/catalog/controller/extension/payment/simplifycommerce.php
+++ b/src/upload/catalog/controller/extension/payment/simplifycommerce.php
@@ -21,6 +21,29 @@ class ControllerExtensionPaymentSimplifyCommerce extends Controller {
 		return 100 * $this->currency->format($order_info['total'], $order_info['currency_code'], $order_info['currency_value'], false);
 	}
 
+    protected function attempt_transliteration($field) {
+	    $copy = $field;
+        $encoding = mb_detect_encoding($field);
+        if ($encoding !== 'ASCII') {
+            if (!function_exists('transliterator_transliterate')) {
+                $field = transliterator_transliterate('Any-Latin; Latin-ASCII', $field);
+		    } else if (function_exists('iconv')) {
+                // fall back to iconv if intl module not available
+                $field = iconv($encoding, 'ASCII//TRANSLIT//IGNORE', $field);
+                $field = str_ireplace('?', '', $field);
+                $field = trim($field);
+            } else {
+                // no transliteration possible, revert to original field
+                return $field;
+            }
+            if (!$field) {
+                // if translit turned the string into any false-like value, return original instead
+                return $copy;
+            }
+        }
+        return $field;
+    }
+
 	public function index() {
 		$this->load->language('extension/payment/simplifycommerce');
 		$this->load->model('checkout/order');
@@ -44,7 +67,7 @@ class ControllerExtensionPaymentSimplifyCommerce extends Controller {
 
 		$order_info = $this->model_checkout_order->getOrder($this->session->data['order_id']);
 
-		$data['store_name'] = $order_info["store_name"];
+		$data['store_name'] = $this->attempt_transliteration($order_info["store_name"]);
 
 		$data['amount'] = $this->calcAmount($order_info);
 

--- a/src/upload/catalog/controller/extension/payment/simplifycommerce.php
+++ b/src/upload/catalog/controller/extension/payment/simplifycommerce.php
@@ -25,7 +25,7 @@ class ControllerExtensionPaymentSimplifyCommerce extends Controller {
 	    $copy = $field;
         $encoding = mb_detect_encoding($field);
         if ($encoding !== 'ASCII') {
-            if (!function_exists('transliterator_transliterate')) {
+            if (function_exists('transliterator_transliterate')) {
                 $field = transliterator_transliterate('Any-Latin; Latin-ASCII', $field);
 		    } else if (function_exists('iconv')) {
                 // fall back to iconv if intl module not available

--- a/src/upload/catalog/view/theme/default/template/extension/payment/simplifycommerce.twig
+++ b/src/upload/catalog/view/theme/default/template/extension/payment/simplifycommerce.twig
@@ -20,7 +20,7 @@
             <button id="simplify-button"
                 data-color="{{ button_color }}"
                 data-sc-key="{{ pub_key  }}"
-                data-name="{{ store_name }}"
+                {% if store_name %}data-name="{{ store_name }}"{% endif %}
                 data-reference="{{ description }}"
                 data-amount="{{ amount }}"
                 data-operation="create.token"


### PR DESCRIPTION
The only field used by OpenCart extension, that could fail with non-ascii characters, seems to be `store_name`
This PR will try to turn any such value into ASCII